### PR TITLE
Update ConsoleTables.nuspec

### DIFF
--- a/ConsoleTables.nuspec
+++ b/ConsoleTables.nuspec
@@ -13,6 +13,6 @@
         <tags>console</tags>
     </metadata>
     <files>
-        <file src="ConsoleTables.Core\bin\Release\ConsoleTables.Core.dll" target="lib\net45\ConsoleTables.Core.dll" />
+        <file src="ConsoleTables.Core\bin\Release\ConsoleTables.Core.dll" target="lib\net40\ConsoleTables.Core.dll" />
     </files>
 </package>


### PR DESCRIPTION
Change the file target path to "lib\net40..." for the Nuget package to allow targeting .NET 4.0 projects.

I missed this on my previous pull request, but I think this will also be necessary when you create a new NuGet package or modify the existing one. I think you should be able to have multiple targets, so that it will support several versions of the .NET framework. I am not sure, but I think that .NET 4.5 projects will be able to use packages targets at .NET 4.0, but not vice-versa.
