### PR TITLE
New table formats: Markdown comaptible and Alternative

### DIFF
--- a/ConsoleTables.Core/ConsoleTable.cs
+++ b/ConsoleTables.Core/ConsoleTable.cs
@@ -21,7 +21,6 @@ namespace ConsoleTables.Core
         {
             foreach (var name in names)
                 Columns.Add(name);
-
             return this;
         }
 
@@ -124,6 +123,41 @@ namespace ConsoleTables.Core
             return builder.ToString();
         }
 
+        public string ToStringAlternative()
+        {
+            var builder = new StringBuilder();
+
+            // find the longest column by searching each row
+            var columnLengths = ColumnLengths();
+
+            // create the string format with padding
+            var format = Format(columnLengths);
+
+            var results = new List<string>();
+
+            // find the longest formatted line
+            var columnHeaders = string.Format(format, Columns.ToArray());
+
+            // add each row
+            Array.ForEach(Rows.Select(row => string.Format(format, row)).ToArray(), results.Add);
+
+            // create the divider
+            var divider = Regex.Replace(columnHeaders, @"[^|]", "-");
+            var dividerPlus = divider.Replace("|", "+");
+
+            builder.AppendLine(dividerPlus);
+            builder.AppendLine(columnHeaders);
+
+            foreach (var row in results)
+            {
+                builder.AppendLine(dividerPlus);
+                builder.AppendLine(row);
+            }
+            builder.AppendLine(dividerPlus);
+
+            return builder.ToString();
+        }
+
         private string Format(List<int> columnLengths)
         {
             var format = (Enumerable.Range(0, Columns.Count)
@@ -153,6 +187,9 @@ namespace ConsoleTables.Core
                 case Core.Format.MarkDown:
                     Console.WriteLine(ToMarkDownString());
                     break;
+                case Core.Format.Alternative:
+                    Console.WriteLine(ToStringAlternative());
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(format), format, null);
             }
@@ -162,6 +199,7 @@ namespace ConsoleTables.Core
     public enum Format
     {
         Default = 0,
-        MarkDown = 1
+        MarkDown = 1,
+        Alternative = 2
     }
 }

--- a/ConsoleTables/Program.cs
+++ b/ConsoleTables/Program.cs
@@ -12,20 +12,27 @@ namespace ConsoleTables
             table.AddRow(1, 2, 3)
                  .AddRow("this line should be longer", "yes it is", "oh");
 
+            Console.WriteLine("\nFORMAT: Default:\n");
             table.Write();
+
+            Console.WriteLine("\nFORMAT: MarkDown:\n");
+            table.Write(Format.MarkDown);
+
+            Console.WriteLine("\nFORMAT: Alternative:\n");
+            table.Write(Format.Alternative);
             Console.WriteLine();
 
             table = new ConsoleTable("I've", "got", "nothing");
             table.Write();
             Console.WriteLine();
-            
+
             var rows = Enumerable.Repeat(new Something(), 10);
 
             ConsoleTable.From<Something>(rows).Write();
 
             rows = Enumerable.Repeat(new Something(), 0);
             ConsoleTable.From<Something>(rows).Write();
-            
+
             Console.ReadKey();
         }
     }

--- a/Readme.md
+++ b/Readme.md
@@ -15,11 +15,42 @@ static void Main(String[] args)
 
     var rows = Enumerable.Repeat(new Something(), 10);
 
-    ConsoleTable.From<Something>(rows).Write();
+    ConsoleTable
+       .From<Something>(rows)
+       .Write(Format.Alternative);
 
     Console.ReadKey();
 }
 ```
+
+## Console output
+```bat
+
+FORMAT: Default:
+
+ --------------------------------------------------
+ | one                        | two       | three |
+ --------------------------------------------------
+ | 1                          | 2         | 3     |
+ --------------------------------------------------
+ | this line should be longer | yes it is | oh    |
+ --------------------------------------------------
+
+ Count: 2
+
+
+FORMAT: Alternative:
+
++----------------------------+-----------+-------+
+| one                        | two       | three |
++----------------------------+-----------+-------+
+| 1                          | 2         | 3     |
++----------------------------+-----------+-------+
+| this line should be longer | yes it is | oh    |
++----------------------------+-----------+-------+
+```
+
+
 
 ## Sample Output (Screenshot)
 


### PR DESCRIPTION
I needed a slightly different format, so added ability to choose default, markdown and alternative.
The markdown can be used with github readme files like this:

| Id                               | Name             | Date                |
|----------------------------------|------------------|---------------------|
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |

Usage of the new format:

```csharp
Console.WriteLine("\nFORMAT: Default:\n");
ConsoleTable.From<Something>(rows).Write();

Console.WriteLine("\nFORMAT: MarkDown:\n");
ConsoleTable.From<Something>(rows).Write(Format.MarkDown);

Console.WriteLine("\nFORMAT: Alternative:\n");
ConsoleTable.From<Something>(rows).Write(Format.Alternative);
```

Examples of the output:

```
FORMAT: Default:

 -----------------------------------------------------------------------------
 | Id                               | Name             | Date                |
 -----------------------------------------------------------------------------
 | 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
 -----------------------------------------------------------------------------
 | 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
 -----------------------------------------------------------------------------
 | 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
 -----------------------------------------------------------------------------
 | 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
 -----------------------------------------------------------------------------
 | 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
 -----------------------------------------------------------------------------

 Count: 10

FORMAT: MarkDown:

| Id                               | Name             | Date                |
|----------------------------------|------------------|---------------------|
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |


FORMAT: Alternative:

+----------------------------------+------------------+---------------------+
| Id                               | Name             | Date                |
+----------------------------------+------------------+---------------------+
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
+----------------------------------+------------------+---------------------+
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
+----------------------------------+------------------+---------------------+
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
+----------------------------------+------------------+---------------------+
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
+----------------------------------+------------------+---------------------+
| 72c0f4cc73eb4fd3b2b4a6896d020e66 | Khalid Abuhkameh | 17-04-2016 23:21:38 |
+----------------------------------+------------------+---------------------+
```