### PR TITLE
Update for .NET Core

### DIFF
--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -194,12 +194,12 @@ namespace ConsoleTables
 
         private static IEnumerable<string> GetColumns<T>()
         {  
-            return typeof(T).GetTypeInfo().DeclaredProperties.Select(x => x.Name).ToArray();
+            return typeof(T).GetProperties().Select(x => x.Name).ToArray();
         }
 
         private static object GetColumnValue<T>(object target, string column)
         {
-            return typeof(T).GetTypeInfo().DeclaredProperties.Single(p => p.Name == column).GetValue(target, null);
+            return typeof(T).GetProperty(column).GetValue(target, null);
         }
     }
 

--- a/src/ConsoleTables/ConsoleTables.csproj
+++ b/src/ConsoleTables/ConsoleTables.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.2;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <PackageId>ConsoleTables</PackageId>
     <PackageVersion>2.0.0-alpha1</PackageVersion>
     <Description>Allows you to print out objects in a table view in a console application. Should be helpful for the diehard console fans.</Description>
@@ -25,7 +25,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions">
       <Version>4.3.0</Version>
     </PackageReference>

--- a/src/ConsoleTables/ConsoleTables.csproj
+++ b/src/ConsoleTables/ConsoleTables.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net40</TargetFrameworks>
     <PackageId>ConsoleTables</PackageId>
     <PackageVersion>2.0.0-alpha1</PackageVersion>
     <Description>Allows you to print out objects in a table view in a console application. Should be helpful for the diehard console fans.</Description>
@@ -30,7 +30,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
   </ItemGroup>


### PR DESCRIPTION
1. This fixes the issue in PR #14 to target netstandard 1.3 since 1.2 was a mistake.
2. It turns out it is possible to target net40. I missed what @onovotny did with the shim package for extension methods.