### PR TITLE
Don't depend on netstandard libs for net40.

### DIFF
--- a/src/ConsoleTables/ConsoleTables.csproj
+++ b/src/ConsoleTables/ConsoleTables.csproj
@@ -15,7 +15,7 @@
     <Compile Include="**\*.cs" />
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="NETStandard.Library">
       <Version>1.6.1</Version>
     </PackageReference>
@@ -24,7 +24,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="System.Reflection.TypeExtensions">
       <Version>4.3.0</Version>
     </PackageReference>


### PR DESCRIPTION
This fixes a small issue with the nuget packaging. As it was, the `net40` target TFM lists the NetStandard libraries as a dependency. This fixes that.