### PR TITLE
Added a new format: Format.Minimal

### DIFF
--- a/src/ConsoleTables.Sample/ConsoleTables.Sample.csproj
+++ b/src/ConsoleTables.Sample/ConsoleTables.Sample.csproj
@@ -1,24 +1,12 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\ConsoleTables\ConsoleTables.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/src/ConsoleTables.Sample/Program.cs
+++ b/src/ConsoleTables.Sample/Program.cs
@@ -22,6 +22,10 @@ namespace ConsoleTables.Sample
             table.Write(Format.Alternative);
             Console.WriteLine();
 
+            Console.WriteLine("\nFORMAT: Minimal:\n");
+            table.Write(Format.Minimal);
+            Console.WriteLine();
+
             table = new ConsoleTable("I've", "got", "nothing");
             table.Write();
             Console.WriteLine();

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -108,7 +108,8 @@ namespace ConsoleTables
             return builder.ToString();
         }
 
-        public string ToMarkDownString()
+        public string ToMarkDownString() => ToMarkDownString('|');
+        private string ToMarkDownString(char delimiter)
         {
             var builder = new StringBuilder();
 
@@ -116,7 +117,7 @@ namespace ConsoleTables
             var columnLengths = ColumnLengths();
 
             // create the string format with padding
-            var format = Format(columnLengths);
+            var format = Format(columnLengths, delimiter);
 
             // find the longest formatted line
             var columnHeaders = string.Format(format, Columns.ToArray());
@@ -133,6 +134,8 @@ namespace ConsoleTables
 
             return builder.ToString();
         }
+
+        public string ToMinimalString() => ToMarkDownString(char.MinValue);
 
         public string ToStringAlternative()
         {
@@ -167,11 +170,12 @@ namespace ConsoleTables
             return builder.ToString();
         }
 
-        private string Format(List<int> columnLengths)
+        private string Format(List<int> columnLengths, char delimiter = '|')
         {
+            var delimiterStr = delimiter == char.MinValue ? string.Empty : delimiter.ToString();
             var format = (Enumerable.Range(0, Columns.Count)
-                .Select(i => " | {" + i + ",-" + columnLengths[i] + "}")
-                .Aggregate((s, a) => s + a) + " |").Trim();
+                .Select(i => " "+ delimiterStr + " {" + i + ",-" + columnLengths[i] + "}")
+                .Aggregate((s, a) => s + a) + " " + delimiterStr).Trim();
             return format;
         }
 
@@ -199,6 +203,9 @@ namespace ConsoleTables
                 case ConsoleTables.Format.Alternative:
                     Console.WriteLine(ToStringAlternative());
                     break;
+                case ConsoleTables.Format.Minimal:
+                    Console.WriteLine(ToMinimalString());
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(format), format, null);
             }
@@ -225,6 +232,7 @@ namespace ConsoleTables
     {
         Default = 0,
         MarkDown = 1,
-        Alternative = 2
+        Alternative = 2,
+        Minimal = 3
     }
 }

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -108,7 +108,11 @@ namespace ConsoleTables
             return builder.ToString();
         }
 
-        public string ToMarkDownString() => ToMarkDownString('|');
+        public string ToMarkDownString()
+        {
+            return ToMarkDownString('|');
+        }
+
         private string ToMarkDownString(char delimiter)
         {
             var builder = new StringBuilder();
@@ -135,7 +139,10 @@ namespace ConsoleTables
             return builder.ToString();
         }
 
-        public string ToMinimalString() => ToMarkDownString(char.MinValue);
+        public string ToMinimalString()
+        {
+            return ToMarkDownString(char.MinValue);
+        }
 
         public string ToStringAlternative()
         {

--- a/src/ConsoleTables/ConsoleTables.csproj
+++ b/src/ConsoleTables/ConsoleTables.csproj
@@ -1,5 +1,4 @@
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net40</TargetFrameworks>
     <PackageId>ConsoleTables</PackageId>
@@ -11,19 +10,6 @@
     <PackageTags>console</PackageTags>
     <Authors>khalidabuhakmeh</Authors>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
-    <PackageReference Include="NETStandard.Library">
-      <Version>1.6.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="System.Reflection.TypeExtensions">
       <Version>4.3.0</Version>
@@ -33,5 +19,4 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Added a Format.Minimal that does not use the pipe delimiter for scenarios where you need a cleaner simpler output.

I also had to update the csproj files because the solution gave compilation errors in VS 2017:

1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\Microsoft.Common.CurrentVersion.targets(737,5): error : The OutputPath property is not set for project 'ConsoleTables.csproj'.  Please check to make sure that you have specified a valid combination of Configuration and Platform for this project.  Configuration='Debug'  Platform='AnyCPU'.  This error may also appear if some other project is trying to follow a project-to-project reference to this project, this project has been unloaded or is not included in the solution, and the referencing project does not build using the same or an equivalent Configuration or Platform.
1>Done building project "ConsoleTables.csproj" -- FAILED.

And addressed the warning:
1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\Sdks\Microsoft.NET.Sdk\build\Microsoft.NET.Sdk.DefaultItems.targets(101,5): warning : A PackageReference for 'NETStandard.Library' was included in your project. This package is implicitly referenced by the .NET SDK and you do not typically need to reference it from your project. For more information, see https://aka.ms/sdkimplicitrefs

