### PR TITLE
Adds option for setting the output TextWriter

### DIFF
--- a/ConsoleTables.Tests/ConsoleTableTest.cs
+++ b/ConsoleTables.Tests/ConsoleTableTest.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace ConsoleTables.Tests
@@ -84,6 +86,37 @@ $@"| Name      | Age |
 |-----------|-----|
 | Alexandre |  36 |
 ", table);
+        }
+
+        [Fact]
+        public void OutputShouldDefaultToConsoleOut()
+        {
+            var users = new List<User>
+            {
+                new User { Name = "Alexandre" , Age = 36 }
+            };
+
+            var table = ConsoleTable.From(users);
+
+            Assert.Equal(table.Options.OutputTo, Console.Out);
+        }
+
+        [Fact]
+        public void OutputShouldGoToConfiguredOutputWriter()
+        {
+            var users = new List<User>
+            {
+                new User { Name = "Alexandre" , Age = 36 }
+            };
+
+            var testWriter = new StringWriter();
+
+            ConsoleTable
+               .From(users)
+               .Configure(o => o.OutputTo = testWriter)
+               .Write();
+
+            Assert.NotEmpty(testWriter.ToString());
         }
 
         class User

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -241,16 +242,16 @@ namespace ConsoleTables
             switch (format)
             {
                 case ConsoleTables.Format.Default:
-                    Console.WriteLine(ToString());
+                    Options.OutputTo.WriteLine(ToString());
                     break;
                 case ConsoleTables.Format.MarkDown:
-                    Console.WriteLine(ToMarkDownString());
+                    Options.OutputTo.WriteLine(ToMarkDownString());
                     break;
                 case ConsoleTables.Format.Alternative:
-                    Console.WriteLine(ToStringAlternative());
+                    Options.OutputTo.WriteLine(ToStringAlternative());
                     break;
                 case ConsoleTables.Format.Minimal:
-                    Console.WriteLine(ToMinimalString());
+                    Options.OutputTo.WriteLine(ToMinimalString());
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(format), format, null);
@@ -282,6 +283,11 @@ namespace ConsoleTables
         /// Enable only from a list of objects
         /// </summary>
         public Alignment NumberAlignment { get; set; } = Alignment.Left;
+
+        /// <summary>
+        /// The <see cref="TextWriter"/> to write to. Defaults to <see cref="Console.Out"/>.
+        /// </summary>
+        public TextWriter OutputTo { get; set; } = Console.Out;
     }
 
     public enum Format


### PR DESCRIPTION
**Context**

Sometimes it's useful to decide where the output goes, other than `Console`. I typically find this helpful when I'm building command line apps.

** If applied this PR will: **

Enable the developer to configure where the output goes (e.g.  `Console.Out`, `Console.Error`)