### PR TITLE
update framework version to netcoreapp3.1

### DIFF
--- a/ConsoleTables.Tests/ConsoleTables.Tests.csproj
+++ b/ConsoleTables.Tests/ConsoleTables.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 version: '{build}'
 pull_requests:
   do_not_increment_build_number: true

--- a/src/ConsoleTables.Sample/ConsoleTables.Sample.csproj
+++ b/src/ConsoleTables.Sample/ConsoleTables.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/ConsoleTables/ConsoleTables.csproj
+++ b/src/ConsoleTables/ConsoleTables.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net40</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard1.3;net40</TargetFrameworks>
     <PackageId>ConsoleTables</PackageId>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Description>Allows you to print out objects in a table view in a console application. Should be helpful for the diehard console fans.</Description>


### PR DESCRIPTION
The framework versions have not had an update in a while. It would be great to be able to use this package in a netcore 3.1 app. 

- Added netcoreapp3.1 to main csproj
- Replace netcoreapp versions in sample and test project both to netcoreapp 3.1
- All tests run and passed
- Update AppVeyor image used to VS2019 to handle .NET Core 3.1