### PR TITLE
Ignore properties marked with [Browsable(false)]

### DIFF
--- a/ConsoleTables.Tests/ConsoleTableTest.cs
+++ b/ConsoleTables.Tests/ConsoleTableTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using Xunit;
 
@@ -123,6 +124,8 @@ $@"| Name      | Age |
         {
             public string Name { get; set; }
             public int Age { get; set; }
+
+            [Browsable(false)] public string NameAllCaps => Name.ToUpperInvariant();
         }
     }
 }

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -260,7 +261,7 @@ namespace ConsoleTables
 
         private static IEnumerable<string> GetColumns<T>()
         {
-            return typeof(T).GetProperties().Select(x => x.Name).ToArray();
+            return GetProperties<T>().Select(x => x.Name).ToArray();
         }
 
         private static object GetColumnValue<T>(object target, string column)
@@ -270,7 +271,15 @@ namespace ConsoleTables
 
         private static IEnumerable<Type> GetColumnsType<T>()
         {
-            return typeof(T).GetProperties().Select(x => x.PropertyType).ToArray();
+            return GetProperties<T>().Select(x => x.PropertyType).ToArray();
+        }
+
+        private static IEnumerable<PropertyInfo> GetProperties<T>()
+        {
+            return typeof(T).GetProperties().Where(x =>
+                x.GetCustomAttributes(typeof(BrowsableAttribute), inherit: true)
+                    .Cast<BrowsableAttribute>()
+                    .All(attr => attr.Browsable));
         }
     }
 

--- a/src/ConsoleTables/ConsoleTables.csproj
+++ b/src/ConsoleTables/ConsoleTables.csproj
@@ -26,6 +26,11 @@
   <PropertyGroup>
     <MinVerMinimumMajorMinor>2.2</MinVerMinimumMajorMinor>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.ComponentModel.Primitives">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
     <PackageReference Include="System.Reflection.TypeExtensions">
       <Version>4.3.0</Version>


### PR DESCRIPTION
Many GUI components such as table and property grids ignore properties marked with the `[Browsable(false)]` attribute.

This PR adds that same behavior to ConsoleTables.