### PR TITLE
Typo in ConsoleTable.cs

### DIFF
--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -53,7 +53,7 @@ namespace ConsoleTables
 
             if (Columns.Count != values.Length)
                 throw new Exception(
-                    $"The number columns in the row ({Columns.Count}) does not match the values ({values.Length}");
+                    $"The number columns in the row ({Columns.Count}) does not match the values ({values.Length})");
 
             Rows.Add(values);
             return this;


### PR DESCRIPTION
Typo in ConsoleTable.cs. Missing end parenthesis in string.