### PR TITLE
fix when non-English languages and chars width is two

### DIFF
--- a/src/ConsoleTables.Sample/Program.cs
+++ b/src/ConsoleTables.Sample/Program.cs
@@ -9,7 +9,7 @@ namespace ConsoleTables.Sample
         {
             var table = new ConsoleTable("one", "two", "three");
             table.AddRow(1, 2, 3)
-                 .AddRow("this line should be longer", "yes it is", "oh");
+                 .AddRow("this line should be longer 哈哈哈哈", "yes it is", "oh");
 
             Console.WriteLine("\nFORMAT: Default:\n");
             table.Write();


### PR DESCRIPTION
I find that string.Format("{0,xx}",row) is not working on Linux. I run my app on Linux and it display error。