### PR TITLE
feature : draw a table from a dictionary<string,dictionary<string,object>>

### DIFF
--- a/ConsoleTables.Tests/ConsoleTableTest.cs
+++ b/ConsoleTables.Tests/ConsoleTableTest.cs
@@ -119,6 +119,41 @@ $@"| Name      | Age |
             Assert.NotEmpty(testWriter.ToString());
         }
 
+        [Fact]
+        public void TestDictionaryTable()
+        {
+            Dictionary<string, Dictionary<string, object>> data = new Dictionary<string, Dictionary<string, object>>()
+            {
+                {"A", new Dictionary<string, object>()
+                {
+                    { "A", true },
+                    { "B", false },
+                    { "C", true },
+                }},
+                {"B", new Dictionary<string, object>()
+                {
+                    { "A", false },
+                    { "B", true },
+                    { "C", false },
+                }},
+                {"C", new Dictionary<string, object>()
+                {
+                    { "A", false },
+                    { "B", false },
+                    { "C", true },
+                }}
+            };
+            var table = ConsoleTable.FromDictionary(data);
+
+            Assert.Equal(@"|   | A     | B     | C     |
+|---|-------|-------|-------|
+| A | True  | False | True  |
+| B | False | True  | False |
+| C | False | False | True  |
+",table.ToMarkDownString());
+
+        }
+
         class User
         {
             public string Name { get; set; }

--- a/src/ConsoleTables.Sample/Program.cs
+++ b/src/ConsoleTables.Sample/Program.cs
@@ -1,12 +1,44 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ConsoleTables.Sample
 {
     class Program
     {
+        
+        static void TestDictionaryTable()
+        {
+            Dictionary<string, Dictionary<string, object>> data = new Dictionary<string, Dictionary<string, object>>()
+            {
+                {"A", new Dictionary<string, object>()
+                {
+                    { "A", true },
+                    { "B", false },
+                    { "C", true },
+                }},
+                {"B", new Dictionary<string, object>()
+                {
+                    { "A", false },
+                    { "B", true },
+                    { "C", false },
+                }},
+                {"C", new Dictionary<string, object>()
+                {
+                    { "A", false },
+                    { "B", false },
+                    { "C", true },
+                }}
+            };
+            var table = ConsoleTable.FromDictionary(data);
+
+            Console.WriteLine(table.ToString());
+
+        }
+        
         static void Main(string[] args)
         {
+            TestDictionaryTable();
             var table = new ConsoleTable("one", "two", "three");
             table.AddRow(1, 2, 3)
                  .AddRow("this line should be longer", "yes it is", "oh");

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -65,6 +65,36 @@ namespace ConsoleTables
             return this;
         }
 
+
+        public static ConsoleTable FromDictionary(Dictionary<string, Dictionary<string, object>> values)
+        {
+            var table = new ConsoleTable();
+
+            var columNames = values.SelectMany(x => x.Value.Keys).Distinct().ToList();
+            columNames.Insert(0,"");
+            table.AddColumn(columNames);
+            foreach (var row in values)
+            {
+                List<object> r = new List<object>();
+                r.Add(row.Key);
+                foreach (var columName in columNames.Skip(1))
+                {
+                    if (row.Value.ContainsKey(columName))
+                    {
+                        r.Add(row.Value[columName]);
+                    }
+                    else
+                    {
+                        r.Add("");
+                    }
+                }
+
+                table.AddRow(r.Cast<object>().ToArray());
+            }
+
+            return table;
+        }
+
         public static ConsoleTable From<T>(IEnumerable<T> values)
         {
             var table = new ConsoleTable


### PR DESCRIPTION
Hello,

This pull-request allows to display a table from a dictionary<string,dictionary<string,object>>
where first level dictionary is a row and second level defines columns.

```c#
Dictionary<string, Dictionary<string, object>> data = new Dictionary<string, Dictionary<string, object>>()
            {
                {"A", new Dictionary<string, object>()
                {
                    { "A", true },
                    { "B", false },
                    { "C", true },
                }},
                {"B", new Dictionary<string, object>()
                {
                    { "A", false },
                    { "B", true },
                    { "C", false },
                }},
                {"C", new Dictionary<string, object>()
                {
                    { "A", false },
                    { "B", false },
                    { "C", true },
                }}
            };
```

will display :

|   | A     | B     | C     |
|---|-------|-------|-------|
| A | True  | False | True  |
| B | False | True  | False |
| C | False | False | True  |

thanks for reviewing