### PR TITLE
Add support console data from datatable 

### DIFF
--- a/ConsoleTables.Tests/ConsoleTableTest.cs
+++ b/ConsoleTables.Tests/ConsoleTableTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using Xunit;
 
@@ -174,6 +175,25 @@ $@"| Name      | Age |
 | A | True  | False | True  |
 | B | False | True  | False |
 | C | False | False | True  |
+",table.ToMarkDownString());
+
+        }
+        [Fact]
+        public void TestDataTable()
+        {
+            DataTable data = new DataTable();
+            data.Columns.Add("A", typeof(bool));
+            data.Columns.Add("B", typeof(bool));
+            data.Columns.Add("C", typeof(bool));
+            data.Rows.Add(true, false, true);
+            data.Rows.Add(false, true, false);
+            data.Rows.Add(false, false, true);
+            var table = ConsoleTable.From(data);
+            Assert.Equal(@"| A     | B     | C     |
+|-------|-------|-------|
+| True  | False | True  |
+| False | True  | False |
+| False | False | True  |
 ",table.ToMarkDownString());
 
         }

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -103,6 +104,27 @@ namespace ConsoleTables
                 var propertyValues
                 in values.Select(value => columns.Select(column => GetColumnValue<T>(value, column)))
             ) table.AddRow(propertyValues.ToArray());
+
+            return table;
+        }
+
+        public static ConsoleTable From(DataTable dataTable)
+        {
+            var table = new ConsoleTable();
+
+            var columns = dataTable.Columns
+                .Cast<DataColumn>()
+                .Select(x => x.ColumnName)
+                .ToList();
+
+            table.AddColumn(columns);
+
+            foreach (DataRow row in dataTable.Rows)
+            {
+                var items = row.ItemArray.Select(x => x is byte[] data ? Convert.ToBase64String(data) : x.ToString())
+                    .ToArray();
+                table.AddRow(items);
+            }
 
             return table;
         }


### PR DESCRIPTION
This is pull request support with data is DataTable
Full example 
```cs
ConsoleTable
            .From(record)
            .Configure(o => o.NumberAlignment = Alignment.Left)
            .Configure(o => o.EnableCount = true)
            .Configure(o => o.OutputTo = Console.Out)
            .Write(Format.MarkDown);
```