### PR TITLE
bugfix: corrected the incorrect format in `ToMinimalString`

### DIFF
--- a/ConsoleTables.Tests/ConsoleTableTest.cs
+++ b/ConsoleTables.Tests/ConsoleTableTest.cs
@@ -231,6 +231,22 @@ $@"| Name      | Age |
 
         }
 
+        [Fact]
+        public void TestMinimalFormating()
+        {
+            var table = new ConsoleTable("one", "two", "three")
+                .AddRow(1, 2, 3)
+                .AddRow("this line should be longer 哈哈哈哈", "yes it is", "oh")
+                .ToMinimalString();
+            Assert.Equal("""
+                         one                                  two        three 
+                         ------------------------------------------------------
+                         1                                    2          3     
+                         this line should be longer 哈哈哈哈  yes it is  oh    
+
+                         """, table);
+        }
+
         class User
         {
             public string Name { get; set; }

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -185,6 +185,10 @@ namespace ConsoleTables
 
         private void SetFormats(List<int> columnLengths, List<string> columnAlignment)
         {
+            SetFormats(columnLengths, columnAlignment, "|");
+        }
+        private void SetFormats(List<int> columnLengths, List<string> columnAlignment, string delimiterStr)
+        {
             var allLines = new List<object[]>();
             allLines.Add(Columns.ToArray());
             allLines.AddRange(Rows);
@@ -196,9 +200,9 @@ namespace ConsoleTables
                     {
                         var value = d[i]?.ToString() ?? "";
                         var length = columnLengths[i] - (GetTextWidth(value) - value.Length);
-                        return " | {" + i + "," + columnAlignment[i] + length + "}";
+                        return " " + delimiterStr + " {" + i + "," + columnAlignment[i] + length + "}";
                     })
-                    .Aggregate((s, a) => s + a) + " |";
+                    .Aggregate((s, a) => s + a) + " " + delimiterStr;
             }).ToList();
         }
 
@@ -282,9 +286,9 @@ namespace ConsoleTables
                 .Select(GetNumberAlignment)
                 .ToList();
 
-            SetFormats(columnLengths, columnAlignment);
-
             var delimiterStr = delimiter == char.MinValue ? string.Empty : delimiter.ToString();
+            SetFormats(columnLengths, columnAlignment, delimiterStr);
+
             var format = (Enumerable.Range(0, Columns.Count)
                 .Select(i => " " + delimiterStr + " {" + i + "," + columnAlignment[i] + columnLengths[i] + "}")
                 .Aggregate((s, a) => s + a) + " " + delimiterStr).Trim();


### PR DESCRIPTION
Affected since [this commit](https://github.com/khalidabuhakmeh/ConsoleTables/commit/78df8bdc0368eaf883063b6215bfad9c713c4a36#diff-9594a262b527bfc2d1ee4d2246d122ab432ece8eb013d1f6126a9b41c3b327c5R154) which hardcoded `|` as the delimiter, although `ToMinimalString` does not use a delimiter.