### PR TITLE
Add option to exclude the header row when printing table

### DIFF
--- a/ConsoleTables.Tests/ConsoleTableTest.cs
+++ b/ConsoleTables.Tests/ConsoleTableTest.cs
@@ -177,7 +177,30 @@ $@"| Name      | Age |
             Assert.NotEmpty(testWriter.ToString());
         }
 
-        [Fact]
+		[Fact]
+		public void WhenConfiguredToExcludedHeaderRowOutputShouldNotConaintaHeaders()
+		{
+			var testWriter = new StringWriter();
+
+			var headerList = new List<string> { "Header1", "Header2", "Header3" };
+
+			var table = new ConsoleTable();
+			table.AddColumn(headerList);
+			table.AddRow("valA1", "valA2", "valA3");
+			table.AddRow("valB1", "valB2", "valB3");
+			table.AddRow("valC1", "valC2", "valC3");
+			
+			table.Configure(o => o.IncludeHeaderRow = false)
+				.Write();
+			string tableOutput = testWriter.ToString();
+
+			foreach (string header in headerList)
+			{
+				Assert.DoesNotContain(header, tableOutput);
+			}
+		}
+
+		[Fact]
         public void TestDictionaryTable()
         {
             Dictionary<string, Dictionary<string, object>> data = new Dictionary<string, Dictionary<string, object>>()

--- a/src/ConsoleTables.Sample/Program.cs
+++ b/src/ConsoleTables.Sample/Program.cs
@@ -82,7 +82,16 @@ static class Program
 
         noCount.AddRow(1, 2, 3).Write();
 
-        Console.ReadKey();
+		Console.WriteLine("\nHeader Row Excluded From Output");
+		table = new ConsoleTable("Header1", "Header2", "Header3");
+		table.AddRow("valA1", "valA2", "valA3");
+		table.AddRow("valB1", "valB2", "valB3");
+		table.AddRow("valC1", "valC2", "valC3");
+		table
+			.Configure(o => o.IncludeHeaderRow = false)
+			.Write(Format.Minimal);
+
+		Console.ReadKey();
     }
 }
 

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -162,8 +162,11 @@ namespace ConsoleTables
             // create the divider
             var divider = " " + string.Join("", Enumerable.Repeat("-", longestLine - 1)) + " ";
 
-            builder.AppendLine(divider);
-            builder.AppendLine(columnHeaders);
+			if(Options.IncludeHeaderRow)
+			{
+				builder.AppendLine(divider);
+				builder.AppendLine(columnHeaders);
+			}
 
             foreach (var row in results)
             {
@@ -235,8 +238,13 @@ namespace ConsoleTables
             // create the divider
             var divider = Regex.Replace(columnHeaders, "[^|]", "-");
 
-            builder.AppendLine(columnHeaders);
-            builder.AppendLine(divider);
+
+			if (Options.IncludeHeaderRow)
+			{
+				builder.AppendLine(columnHeaders);
+				builder.AppendLine(divider);
+			}
+
             results.ForEach(row => builder.AppendLine(row));
 
             return builder.ToString();
@@ -261,8 +269,11 @@ namespace ConsoleTables
             var divider = Regex.Replace(columnHeaders, "[^| ]", "-");
             var dividerPlus = divider.Replace("|", "+");
 
-            builder.AppendLine(dividerPlus);
-            builder.AppendLine(columnHeaders);
+			if (Options.IncludeHeaderRow)
+			{
+				builder.AppendLine(dividerPlus);
+				builder.AppendLine(columnHeaders);
+			}
 
             foreach (var row in results)
             {
@@ -364,9 +375,12 @@ namespace ConsoleTables
         /// The <see cref="TextWriter"/> to write to. Defaults to <see cref="Console.Out"/>.
         /// </summary>
         public TextWriter OutputTo { get; set; } = Console.Out;
-    }
 
-    public enum Format
+		public bool IncludeHeaderRow { get; set; } = false;
+
+	}
+
+	public enum Format
     {
         Default = 0,
         MarkDown = 1,

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -376,7 +376,7 @@ namespace ConsoleTables
         /// </summary>
         public TextWriter OutputTo { get; set; } = Console.Out;
 
-		public bool IncludeHeaderRow { get; set; } = false;
+		public bool IncludeHeaderRow { get; set; } = true;
 
 	}
 


### PR DESCRIPTION
I wanted to have a console app load multiple pages of data and display it on the same table, so I wanted to be able to just print a set of rows without the header