### PR TITLE
Added Wordbreak and Default WordBreak Delimiter

### DIFF
--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -14,6 +14,9 @@ namespace ConsoleTables
         public IList<object> Columns { get; }
         public IList<object[]> Rows { get; }
 
+        public int MaxWidth { get; set; } = 40;
+        public char WordBreakDelimiter { get; private set; }
+
         public ConsoleTableOptions Options { get; }
         public Type[] ColumnTypes { get; private set; }
 
@@ -36,6 +39,7 @@ namespace ConsoleTables
         {
             Options = options ?? throw new ArgumentNullException("options");
             Rows = new List<object[]>();
+            WordBreakDelimiter = ' ';
             Columns = new List<object>(options.Columns);
         }
 
@@ -43,6 +47,12 @@ namespace ConsoleTables
         {
             foreach (var name in names)
                 Columns.Add(name);
+            return this;
+        }
+
+        public ConsoleTable SetWordBreakDelimiter(char delimiter)
+        {
+            WordBreakDelimiter = delimiter;
             return this;
         }
 
@@ -187,6 +197,38 @@ namespace ConsoleTables
         {
             var allLines = new List<object[]>();
             allLines.Add(Columns.ToArray());
+
+            for (var i = 0; i < Rows.Count; i++)
+            {
+                var row = Rows[i];
+
+                if (row.Any(o => o != null && o.ToString().Length > MaxWidth)) //checks if any column exceeds the MaxWidth
+                {
+                    var newRow = new object[row.Length];
+                    for (var j = 0; j < row.Length; j++) //loop through cells
+                    {
+                        var cellStr = row[j]?.ToString() ?? "";
+                        if (cellStr.Length > MaxWidth) //if cell exceeds MaxWidth
+                        {
+                            var cutCell = cellStr[..MaxWidth]; //cut the cell
+                            var leftOver = cellStr[MaxWidth..]; //into two parts
+                            if (cutCell[^1] != ' ' && cutCell[0] != ' ') //if the cut is in the middle of a word
+                            {
+                                var lastSpace = cutCell.LastIndexOf(WordBreakDelimiter); //find the last WordBreak Delimiter of the first cell
+                                if (lastSpace > 0) //if there is a space
+                                {
+                                    cutCell = cellStr[..lastSpace]; //cut the cell at the last space
+                                    leftOver = cellStr[lastSpace..]; //the leftover is the rest of the cell
+                                }//if there is no space, the cell will be cut at MaxWidth
+                            }
+                            newRow[j] = leftOver.Trim();
+                            Rows[i][j] = cutCell.Trim();
+                        }
+                    }
+                    Rows.Insert(i + 1, newRow);
+                }
+            }
+
             allLines.AddRange(Rows);
 
             Formats = allLines.Select(d =>


### PR DESCRIPTION
I added the ability to break long strings into mutliple rows.
Default MaxWidth is 40 and Default Delimiter is Whitespace
Feel free to request any changes
I need this for me personally but saw someone asking for it.

How does it work:
1. checked if the row contains any column longer than MaxWidth
2. loop through Cells finding all cells with excess length
3. split them into two parts at exactly the max width
4. test if it was cut in the middle of a word (last character of the cut text and first character of the leftover text)
5. if so, it searches for a whitespace before the cut text and cuts the original values again if one was found
6. else it will be cut at MaxWidth (e.g URLs)
7. a new row is added beneath the current row (this will ensure to check if the new content is still too long)

Things the user needs to keep in mind:
if there are Characters with UnicodeWidth longer than 1 it will look like this:

![grafik](https://github.com/user-attachments/assets/8bd778f3-bbc0-4998-ad30-e2d83163507a)

for me thats only because I parse data from the web and done decode anything => user error
