### PR TITLE
Work with ANSI escape codes

### DIFF
--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -266,7 +266,7 @@ namespace ConsoleTables
             if (value == null)
                 return 0;
 
-            var length = value.ToCharArray().Sum(c => UnicodeCalculator.GetWidth(c));
+            var length = AnsiRegex.Replace(value, "").ToCharArray().Sum(GetCharWidth);
             return length;
         }
 
@@ -359,14 +359,15 @@ namespace ConsoleTables
                 : "-";
         }
 
+        private static int GetCharWidth(char c) => UnicodeCalculator.GetWidth(c);
+
         private List<int> ColumnLengths()
         {
-            int charWidth(char c) => UnicodeCalculator.GetWidth(c);
             var columnLengths = Columns
                 .Select((t, i) => Rows.Select(x => x[i])
                     .Union(new[] { Columns[i] })
                     .Where(x => x != null)
-                    .Max(x => AnsiRegex.Replace(x.ToString(), "").ToCharArray().Sum(charWidth)))
+                    .Max(x => AnsiRegex.Replace(x.ToString(), "").ToCharArray().Sum(GetCharWidth)))
                 .ToList();
             return columnLengths;
         }

--- a/src/ConsoleTables/ConsoleTable.cs
+++ b/src/ConsoleTables/ConsoleTable.cs
@@ -11,6 +11,8 @@ namespace ConsoleTables
 {
     public class ConsoleTable
     {
+        private static readonly Regex AnsiRegex = new Regex(@"\e\[[0-9;]*m", RegexOptions.Compiled);
+
         public IList<object> Columns { get; }
         public IList<object[]> Rows { get; }
 
@@ -359,11 +361,12 @@ namespace ConsoleTables
 
         private List<int> ColumnLengths()
         {
+            int charWidth(char c) => UnicodeCalculator.GetWidth(c);
             var columnLengths = Columns
                 .Select((t, i) => Rows.Select(x => x[i])
                     .Union(new[] { Columns[i] })
                     .Where(x => x != null)
-                    .Select(x => x.ToString().ToCharArray().Sum(c => UnicodeCalculator.GetWidth(c))).Max())
+                    .Max(x => AnsiRegex.Replace(x.ToString(), "").ToCharArray().Sum(charWidth)))
                 .ToList();
             return columnLengths;
         }


### PR DESCRIPTION
Strip out ANSI escape codes when calculating string lengths